### PR TITLE
Always send timestamps once negotiated

### DIFF
--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -62,8 +62,7 @@ Paths"
 --- abstract
 
 This document defines an extension to the QUIC transport protocol which supports
-reporting multiple packet receive timestamps using a new ACK_EXTENDED
-frame type which can carry multiple optional fields.
+reporting multiple packet receive timestamps for post-handshake packets.
 
 
 --- middle
@@ -105,37 +104,16 @@ per round-trip in order to best measure the network.
 
 {::boilerplate bcp14-tagged}
 
-# Enabling Extensibility in the ACK frame {#extensibility}
-
-The QUIC transport protocol defines two different frame types for acknowledgements
-{{Section 19.3 of !RFC9000}}. The endpoint sending acknowledgements
-decides which type to use depending on whether it wants to report ECN counts.
-This approach works well with one set of optional fields, but grows exponentially
-with more sets of optional fields.
-
-This document defines a new set of optional fields to report receive timestamps.
-Using a new frame type for each variant of the ACK frame would require adding 2 new
-frame types, for a total of 4. Instead, this document defines one new frame type
-(ACK_EXTENDED), that can carry multiple optional sections, reducing
-the number of new frame types from 2 to 1, and avoids futre extensions causing
-an exponential growth in frame types.
-
-
 
 # ACK_EXTENDED Frame {#frame}
 
-Endpoints send ACK_EXTENDED (type=0xB1 temporary value) frames in place of--and
-in the
-same manner as--regular ACK frames as described in {{Section 13.2 of !RFC9000}}.
-ACK_EXTENDED frames contain additional fields to enable reporting two optional
-sets of fields:
-- ECN Counts (from {{Section 19.3 of !RFC9000}})
-- Receive Timestamps (defined in this document)
+Endpoints send ACK frames as they otherwise would, with 0 or more receive
+timestamps following the ACK ranges.
 
-ACK_EXTENDED frames are formatted as shown in {{fig-frame}}.
+Once the extension has been negotiated, the ACK format becomes:
 
 ~~~
-ACK_EXTENDED Frame {
+ACK Frame {
   Type (i) = 0xB1
   // Fields of the existing ACK (type=0x02) frame:
   Largest Acknowledged (i),
@@ -143,31 +121,15 @@ ACK_EXTENDED Frame {
   ACK Range Count (i),
   First ACK Range (i),
   ACK Range (..) ...,
-  Extended Ack Features (i),
-  // Optional ECN counts (if bit 0 is set in Features)
+  Receive Timestamps (..)
   [ECN Counts (..)],
-  // Optional Receive Timestamps (if bit 1 is set in Features)
-  [Receive Timestamps (..)]
 }
 ~~~
-{: #fig-frame title="ACK_EXTENDED Frame Format"}
+{: #fig-frame title="ACK Frame Format"}
 
 The fields Largest Acknowledged, ACK Delay, ACK Range Count, First ACK Range,
 and ACK Range are the same as for ACK (type=0x02) frames specified in {{Section
 19.3 of !RFC9000}}.
-
-Extended Ack Features: A variable-length integer whose bit-wise
-value indicates which optional fields are included in the ACK. This document
-defines two sets of fields corresponding to the two least significant bits of
-the value:
-- Bit 0 indicates whether ECN count fields are included in the frame
-- Bit 1 indicates whether Receive Timestamps are included in the frame
-
-When Extended Ack Features has bit 0 set, the frame will include ECN Counts as
-defined in {{Section 19.3.2 of !RFC9000}}.
-
-When Extended Ack Feature has bit 1 set, the frame will include the following
-additional fields for the receive timestmaps:
 
 Timestamp Range Count:
 
@@ -250,38 +212,6 @@ Timestamp Deltas:
 
 # Extension Negotiation {#negotiation}
 
-The use of the ACK_EXTENDED frame is negotiated using the following
-three transport parameters ({{Section 7.2 of !RFC9000}}):
-
-extended_ack_features (0xff0a004 temporary value for draft use):
-
-: A variable-length integer indicating the sending endpoint would like to
-  receive ACK_EXTENDED frames with the specified set of features. The bit-wise
-  value of the integer indicates the features the endpoint can accept in the
-  ACK_EXTENDED frame. The value of this paramter is interpreted in the same way
-  as the Extended Ack Features field in the ACK_EXTENDED frame, i.e.,
-    - Bit 0 indicates whether ECN count fields are included in the frame
-    - Bit 1 indicates whether Receive Timestamps are included in the frame
-
-  Upon receiving this parameter, the receiving peer SHOULD send ACK_EXTENDED
-  frames with the features supported by the endpoint which sent the parameter,
-  and set the Extended Ack Features field accordingly. The receiving peer MAY
-  choose to send ACK_EXTENDED frames with less features (and set the equivalent
-  Extended Ack Features field value) if the requested features are not available
-  or there is no data to send (e.g. if no timing information is available for
-  receive timestamps). The receiving peer MAY send regular ACK and ACK_ECN
-  frames, in which case the endpoint MUST still support processing regular ACK
-  frames as defined by {{Section 19.3 of !RFC9000}}.
-
-  ACK_EXTENDED frames written by the peer receiving this parameter MUST not have
-  bits set in the Extended Ack Features that were not set by the sending
-  endpoint
-  in the transport parameter. An endpoint receiving an ACK_EXTENDED frame with
-  features it did not include in the transport parameter should terminate the
-  connection with a PROTOCOL_VIOLATION violation error.
-
-  The receiving peer SHOULD NOT send ACK_EXTENDED frames with 0 features.
-
 max_receive_timestamps_per_ack (0xff0a002 temporary value for draft use):
 
 : A variable-length integer indicating that the maximum number of receive
@@ -323,11 +253,11 @@ endpoints and to make the field more compact.
 
 ## Best-Effort Behavior
 
-Receive timestamps are sent on a best-effort basis and endpoints MUST gracefully
-handle scenarios where receive timestamp information for sent packets is not
-received. Examples of such scenarios are:
+Receive timestamps are sent on a best-effort basis. Endpoints MUST gracefully
+handle scenarios where the receiver does not communicate receive timestamps for
+acknowledged packets. Examples of such scenarios are:
 
-- The packet containing the ACK_EXTENDED frame is lost.
+- The packet containing the ACK frame is lost.
 
 - The sender truncates the number of timestamps sent in order to (a) avoid
   sending more than max_receive_timestamps_per_ack ({{negotiation}}); or (b) fit

--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -217,7 +217,7 @@ max_receive_timestamps_per_ack (0xff0a002 temporary value for draft use):
 : A variable-length integer indicating that the maximum number of receive
   timestamps the sending endpoint would like to receive in an ACK frame.
 
-  Each ACK frame sent MUST NOT contain more than the specified maximum
+  Each ACK frame sent MUST NOT contain more than the peer's maximum
   number of receive timestamps.
 
 receive_timestamps_exponent (0xff0a003 temporary value for draft use):

--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -106,8 +106,11 @@ per round-trip in order to best measure the network.
 
 # ACK Frame Wire Format {#frame}
 
-Endpoints send ACK frames as they otherwise would, with 0 or more receive
-timestamps immediately following the ACK ranges in the ACK Frame.
+Endpoints send ACK frames in 1-RTT packets as they otherwise would, with 0
+or more receive timestamps following the Ack Ranges and optional ECN Counts.
+Receive timestamps MUST NOT be sent in Initial or Handshake packets, because
+the peer would not know to use the extended wire format. ACK frames are never
+sent in 0-RTT packets, so there is no change to 0-RTT.
 
 Once negotiated, the ACK format is identical to RFC9000, but with an
 additional section for receive timestamps at the end:

--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -109,21 +109,20 @@ per round-trip in order to best measure the network.
 Endpoints send ACK frames as they otherwise would, with 0 or more receive
 timestamps immediately following the ACK ranges in the ACK Frame.
 
-Once negotiated, the ACK format is:
+Once negotiated, the ACK format is identical to RFC9000, but with an
+additional section for receive timestamps at the end:
 
 ~~~
 ACK Frame {
-  Type (i) = 0x02/0x03
-  // ACK fields from RFC9000.
+  Type (i) = 0x02..0x03,
   Largest Acknowledged (i),
   ACK Delay (i),
   ACK Range Count (i),
   First ACK Range (i),
   ACK Range (..) ...,
-  // Timestamps.
-  Receive Timestamps (..)
-  // Optional ECN feedback, based on the frame type.
   [ECN Counts (..)],
+  // Timestamp Extension, see {{ts-ranges}}
+  Receive Timestamps (..)
 }
 ~~~
 {: #fig-frame title="ACK Frame Format"}


### PR DESCRIPTION
This approach does not require any new frame types and if for some reason the timestamp extension is negotiated and never used, only wastes one byte per ACK frame.

Closes #7