### PR TITLE
Go back to separate frame types instead of extended ack

### DIFF
--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -272,6 +272,31 @@ received. Examples of such scenarios are:
   sending more than max_receive_timestamps_per_ack ({{negotiation}}); or (b) fit
   the ACK frame into a packet.
 
+
+## Usage with the Multipath Extension for QUIC
+
+The Multipath extension for QUIC ({{?I-D.ietf-quic-multipath}}) defines the
+PATH_ACK frame which contains a path identifier besides the regular ACK frame
+fields. An endpoint that supports both extensions can use another frame type
+PATH_ACK_RECEIVE_TIMESTAMPS to send both the path identifier and the
+receive timestamps.
+
+~~~
+PATH_ACK_RECEIVE_TIMESTAMPS Frame {
+  Type (i) = TBD-00..TBD-01
+  Path Identifier (i),
+  Largest Acknowledged (i),
+  ACK Delay (i),
+  ACK Range Count (i),
+  First ACK Range (i),
+  ACK Range (..) ...,
+  Receive Timestamps (..)
+  [ECN Counts (..)],
+}
+~~~
+{: #fig-mpquic-frame title="PATH_ACK_RECEIVE_TIMESTAMPS Frame Format"}
+
+
 # Security Considerations
 
 TODO Security

--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -1,5 +1,5 @@
 ---
-title: "QUIC Extended Acknowledgement for Reporting Packet Receive Timestamps"
+title: "QUIC Extension for Reporting Packet Receive Timestamps"
 abbrev: "QUIC Receive Timestamps"
 docname: draft-smith-quic-receive-ts-latest
 category: info
@@ -62,8 +62,8 @@ Paths"
 --- abstract
 
 This document defines an extension to the QUIC transport protocol which supports
-reporting multiple packet receive timestamps using a new ACK_EXTENDED
-frame type which can carry multiple optional fields.
+reporting multiple packet receive timestamps using a new ACK_RECEIVE_TIMESTAMPS
+frame.
 
 
 --- middle
@@ -74,8 +74,8 @@ The QUIC Transport Protocol {{!RFC9000}} provides a secure, multiplexed
 connection for transmitting reliable streams of application data.
 
 This document defines an extension to the QUIC transport protocol which supports
-reporting multiple packet receive timestamps using a new ACK_EXTENDED
-frame type.
+reporting multiple packet receive timestamps using a new ACK_RECEIVE_TIMESTAMPS
+frame.
 
 
 # Motivation
@@ -107,69 +107,48 @@ if they are not used by the congestion controller.
 
 {::boilerplate bcp14-tagged}
 
-# Enabling Extensibility in the ACK frame {#extensibility}
+# ACK_RECEIVE_TIMESTAMPS Frame {#frame}
 
-The QUIC transport protocol defines two different frame types for acknowledgements
-{{Section 19.3 of !RFC9000}}. The endpoint sending acknowledgements
-decides which type to use depending on whether it wants to report ECN counts.
-This approach works well with one set of optional fields, but grows exponentially
-with more sets of optional fields.
+The QUIC transport protocol defines the ACK frame for acknowledgements
+{{Section 19.3 of !RFC9000}} with two frame types. The endpoint sending acknowledgements
+chooses the value of frame type field depending on whether it wants to report ECN counts.
 
-This document defines a new set of optional fields to report receive timestamps.
-Using a new frame type for each variant of the ACK frame would require adding 2 new
-frame types, for a total of 4. Instead, this document defines one new frame type
-(ACK_EXTENDED), that can carry multiple optional sections, reducing
-the number of new frame types from 2 to 1, and avoids futre extensions causing
-an exponential growth in frame types.
-
-
-
-# ACK_EXTENDED Frame {#frame}
-
-Endpoints send ACK_EXTENDED (type=0xB1 temporary value) frames in place of--and
-in the
+This extension defines a new frame, ACK_RECEIVE_TIMESTAMPS, which has all the fields from the
+regular ACK frame with new fields for the packet receive timestamps.
+Endpoints send ACK_RECEIVE_TIMESTAMPS frames in place of--and in the
 same manner as--regular ACK frames as described in {{Section 13.2 of !RFC9000}}.
-ACK_EXTENDED frames contain additional fields to enable reporting two optional
-sets of fields:
-- ECN Counts (from {{Section 19.3 of !RFC9000}})
-- Receive Timestamps (defined in this document)
 
-ACK_EXTENDED frames are formatted as shown in {{fig-frame}}.
+
+ACK_RECEIVE_TIMESTAMPS frames are formatted as shown in {{fig-frame}}.
 
 ~~~
-ACK_EXTENDED Frame {
-  Type (i) = 0xB1
-  // Fields of the existing ACK (type=0x02) frame:
+ACK_RECEIVE_TIMESTAMPS Frame {
+  Type (i) = 0xB2..0xB3
   Largest Acknowledged (i),
   ACK Delay (i),
   ACK Range Count (i),
   First ACK Range (i),
   ACK Range (..) ...,
-  Extended Ack Features (i),
-  // Optional ECN counts (if bit 0 is set in Features)
+  Receive Timestamps (..)
+  // ECN counts (if Type=0xB3)
   [ECN Counts (..)],
-  // Optional Receive Timestamps (if bit 1 is set in Features)
-  [Receive Timestamps (..)]
 }
 ~~~
-{: #fig-frame title="ACK_EXTENDED Frame Format"}
+{: #fig-frame title="ACK_RECEIVE_TIMESTAMPS Frame Format"}
 
-The fields Largest Acknowledged, ACK Delay, ACK Range Count, First ACK Range,
-and ACK Range are the same as for ACK (type=0x02) frames specified in {{Section
+The fields Largest Acknowledged, ACK Delay, ACK Range Count, First ACK Range, ACK Range and ECN Counts
+ are the same as for ACK (type=0x02..0x03) frames specified in {{Section
 19.3 of !RFC9000}}.
 
-Extended Ack Features: A variable-length integer whose bit-wise
-value indicates which optional fields are included in the ACK. This document
-defines two sets of fields corresponding to the two least significant bits of
-the value:
-- Bit 0 indicates whether ECN count fields are included in the frame
-- Bit 1 indicates whether Receive Timestamps are included in the frame
+The format of the Receive Timestamps field is shown in {{fig-receive-timestamps}}.
 
-When Extended Ack Features has bit 0 set, the frame will include ECN Counts as
-defined in {{Section 19.3.2 of !RFC9000}}.
-
-When Extended Ack Feature has bit 1 set, the frame will include the following
-additional fields for the receive timestmaps:
+~~~
+Receive Timestamps {
+  Timestamp Range Count (i),
+  Timestamp Range (..) ...
+}
+~~~
+{: #fig-receive-timestamps title="Receive Timestamps Fields"}
 
 Timestamp Range Count:
 
@@ -238,68 +217,34 @@ Timestamp Deltas:
 
   All Timestamp Delta values are decoded by mulitplying the value in the field
   by 2 to the power of the receive_timestamps_exponent transport parameter
-  received by the sender of the ACK_EXTENDED frame (see
+  received by the sender of the ACK_RECEIVE_TIMESTAMPS frame (see
   {{negotiation}}):
 
 # Extension Negotiation {#negotiation}
 
-The use of the ACK_EXTENDED frame is negotiated using the following
+The use of the ACK_RECEIVE_TIMESTAMPS frame is negotiated using the following
 three transport parameters ({{Section 7.2 of !RFC9000}}):
-
-extended_ack_features (0xff0a004 temporary value for draft use):
-
-: A variable-length integer indicating the sending endpoint would like to
-  receive ACK_EXTENDED frames with the specified set of features. The bit-wise
-  value of the integer indicates the features the endpoint can accept in the
-  ACK_EXTENDED frame. The value of this paramter is interpreted in the same way
-  as the Extended Ack Features field in the ACK_EXTENDED frame, i.e.,
-    - Bit 0 indicates whether ECN count fields are included in the frame
-    - Bit 1 indicates whether Receive Timestamps are included in the frame
-
-  Upon receiving this parameter, the receiving peer SHOULD send ACK_EXTENDED
-  frames with the features supported by the endpoint which sent the parameter,
-  and set the Extended Ack Features field accordingly. The receiving peer MAY
-  choose to send ACK_EXTENDED frames with less features (and set the equivalent
-  Extended Ack Features field value) if the requested features are not available
-  or there is no data to send (e.g. if no timing information is available for
-  receive timestamps). The receiving peer MAY send regular ACK and ACK_ECN
-  frames, in which case the endpoint MUST still support processing regular ACK
-  frames as defined by {{Section 19.3 of !RFC9000}}.
-
-  ACK_EXTENDED frames written by the peer receiving this parameter MUST not have
-  bits set in the Extended Ack Features that were not set by the sending
-  endpoint
-  in the transport parameter. An endpoint receiving an ACK_EXTENDED frame with
-  features it did not include in the transport parameter should terminate the
-  connection with a PROTOCOL_VIOLATION violation error.
-
-  The receiving peer SHOULD NOT send ACK_EXTENDED frames with 0 features.
 
 max_receive_timestamps_per_ack (0xff0a002 temporary value for draft use):
 
 : A variable-length integer indicating that the maximum number of receive
-  timestamps the sending endpoint would like to receive in an ACK_EXTENDED
+  timestamps the sending endpoint would like to receive in an ACK_RECEIVE_TIMESTAMPS
   frame.
 
-  The sending endpoint MUST sent this transport parameter if sends the
-  extended_ack_features transport parameter with bit 1 set in its value. A peer
-  that receives this transport parameter but not an extended_ack_features
-  transport paramter with bit 1 set MUST ignore this transport parameter.
-
-  Each ACK_EXTENDED frame sent MUST NOT contain more than the
+  Each ACK_RECEIVE_TIMESTAMPS frame sent MUST NOT contain more than the
   specified maximum number of receive timestamps, but MAY contain fewer or none.
 
 receive_timestamps_exponent (0xff0a003 temporary value for draft use):
 
 : A variable-length integer indicating the exponent to be used when encoding and
-  decoding timestamp delta fields in ACK_EXTENDED frames sent by the
+  decoding timestamp delta fields in ACK_RECEIVE_TIMESTAMPS frames sent by the
   peer (see {{ts-ranges}}). If this value is absent, a default value of 0 is
   assumed (indicating microsecond precision). Values above 20 are invalid.
 
 
 ## Receive Timestamp Basis {#ts-basis}
 
-Endpoints which send ACK_EXTENDED frames must determine a value,
+Endpoints which send ACK_RECEIVE_TIMESTAMPS frames must determine a value,
 receive_timestamp_basis, relative to which all receive timestamps for the
 session will be reported (see {{ts-ranges}}).
 
@@ -321,12 +266,11 @@ Receive timestamps are sent on a best-effort basis and endpoints MUST gracefully
 handle scenarios where receive timestamp information for sent packets is not
 received. Examples of such scenarios are:
 
-- The packet containing the ACK_EXTENDED frame is lost.
+- The packet containing the ACK_RECEIVE_TIMESTAMPS frame is lost.
 
 - The sender truncates the number of timestamps sent in order to (a) avoid
   sending more than max_receive_timestamps_per_ack ({{negotiation}}); or (b) fit
   the ACK frame into a packet.
-
 
 # Security Considerations
 

--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -110,12 +110,13 @@ if they are not used by the congestion controller.
 # ACK_RECEIVE_TIMESTAMPS Frame {#frame}
 
 The QUIC transport protocol defines the ACK frame for acknowledgements
-{{Section 19.3 of !RFC9000}} with two frame types. The endpoint sending acknowledgements
-chooses the value of frame type field depending on whether it wants to report ECN counts.
+{{Section 19.3 of !RFC9000}} with two frame types. The endpoint sending
+acknowledgements chooses the value of frame type field depending on whether
+it wants to report ECN counts.
 
-This extension defines a new frame, ACK_RECEIVE_TIMESTAMPS, which has all the fields from the
-regular ACK frame with new fields for the packet receive timestamps.
-Endpoints send ACK_RECEIVE_TIMESTAMPS frames in place of--and in the
+This extension defines a new frame, ACK_RECEIVE_TIMESTAMPS, which has all the
+fields from the regular ACK frame with new fields for the packet receive
+timestamps Endpoints send ACK_RECEIVE_TIMESTAMPS frames in place of--and in the
 same manner as--regular ACK frames as described in {{Section 13.2 of !RFC9000}}.
 
 
@@ -136,11 +137,12 @@ ACK_RECEIVE_TIMESTAMPS Frame {
 ~~~
 {: #fig-frame title="ACK_RECEIVE_TIMESTAMPS Frame Format"}
 
-The fields Largest Acknowledged, ACK Delay, ACK Range Count, First ACK Range, ACK Range and ECN Counts
- are the same as for ACK (type=0x02..0x03) frames specified in {{Section
-19.3 of !RFC9000}}.
+The fields Largest Acknowledged, ACK Delay, ACK Range Count, First ACK Range,
+ACK Range and ECN Counts are the same as for ACK (type=0x02..0x03) frames
+specified in {{Section 19.3 of !RFC9000}}.
 
-The format of the Receive Timestamps field is shown in {{fig-receive-timestamps}}.
+The format of the Receive Timestamps field is shown in
+{{fig-receive-timestamps}}.
 
 ~~~
 Receive Timestamps {
@@ -228,8 +230,8 @@ three transport parameters ({{Section 7.2 of !RFC9000}}):
 max_receive_timestamps_per_ack (0xff0a002 temporary value for draft use):
 
 : A variable-length integer indicating that the maximum number of receive
-  timestamps the sending endpoint would like to receive in an ACK_RECEIVE_TIMESTAMPS
-  frame.
+  timestamps the sending endpoint would like to receive in an
+  ACK_RECEIVE_TIMESTAMPS frame.
 
   Each ACK_RECEIVE_TIMESTAMPS frame sent MUST NOT contain more than the
   specified maximum number of receive timestamps, but MAY contain fewer or none.
@@ -297,10 +299,11 @@ PATH_ACK_RECEIVE_TIMESTAMPS Frame {
 
 # Examples
 
-To illustrate the usage of the ACK_RECEIVE_TIMESTAMPS frame, consider a peer that sent
-14 packets with numbers 87 to 100.
+To illustrate the usage of the ACK_RECEIVE_TIMESTAMPS frame, consider a peer
+that sent 14 packets with numbers 87 to 100.
 
-Assume the receiver receives packets 87 to 91 and 96 to 100 at the following timestamps relative to the basis:
+Assume the receiver receives packets 87 to 91 and 96 to 100 at the following
+timestamps relative to the basis:
 
 | Packet Number    | Relative Timestamp |
 | ---------------- | ------------------ |
@@ -315,7 +318,8 @@ Assume the receiver receives packets 87 to 91 and 96 to 100 at the following tim
 | 99               | 370                |
 | 100              | 380                |
 
-When it's time to acknowledge these packets, the receiver will send an ACK_RECEIVE_TIMESTAMPS frame with two ranges, as follows:
+When it's time to acknowledge these packets, the receiver will send an
+ACK_RECEIVE_TIMESTAMPS frame with two ranges, as follows:
 
 ~~~
 Largest Acknowledged: 100
@@ -333,7 +337,8 @@ Timestamp Range 2:
   Timestamp Deltas: 20, 10, 10, 5, 5
 ~~~
 
-After that assume that the receiver receives packets 92 to 95 out-of-order at the following timestamps relative to the basis:
+After that assume that the receiver receives packets 92 to 95 out-of-order at
+the following timestamps relative to the basis:
 
 | Packet Number    | Relative Timestamp |
 | ---------------- | ------------------ |
@@ -342,7 +347,8 @@ After that assume that the receiver receives packets 92 to 95 out-of-order at th
 | 94               | 394                |
 | 95               | 395                |
 
-The receiver MAY send a new ACK_RECEIVE_TIMESTAMPS with all of the timestamps, as follows:
+The receiver MAY send a new ACK_RECEIVE_TIMESTAMPS with all of the timestamps,
+as follows:
 
 ~~~
 Largest Acknowledged: 100
@@ -365,7 +371,9 @@ Timestamp Range 2:
   Timestamp Deltas: 20, 10, 10, 5, 5
 ~~~
 
-In this particular scenario, the receiver MAY also choose to report the first timestamp range only since the timestamps for the other two ranges have already been reported.
+In this particular scenario, the receiver MAY also choose to report the first
+timestamp range only since the timestamps for the other two ranges have already
+been reported.
 
 
 

--- a/draft-smith-quic-receive-ts.md
+++ b/draft-smith-quic-receive-ts.md
@@ -257,7 +257,6 @@ Receive timestamps are reported relative to the basis, rather than in absolute
 time to avoid requiring clock synchronization between endpoints and to make
 the frame more compact.
 
-
 # Discussion
 
 ## Best-Effort Behavior
@@ -295,6 +294,79 @@ PATH_ACK_RECEIVE_TIMESTAMPS Frame {
 }
 ~~~
 {: #fig-mpquic-frame title="PATH_ACK_RECEIVE_TIMESTAMPS Frame Format"}
+
+# Examples
+
+To illustrate the usage of the ACK_RECEIVE_TIMESTAMPS frame, consider a peer that sent
+14 packets with numbers 87 to 100.
+
+Assume the receiver receives packets 87 to 91 and 96 to 100 at the following timestamps relative to the basis:
+
+| Packet Number    | Relative Timestamp |
+| ---------------- | ------------------ |
+| 87               | 300                |
+| 88               | 305                |
+| 89               | 310                |
+| 90               | 320                |
+| 91               | 330                |
+| 96               | 350                |
+| 97               | 355                |
+| 98               | 360                |
+| 99               | 370                |
+| 100              | 380                |
+
+When it's time to acknowledge these packets, the receiver will send an ACK_RECEIVE_TIMESTAMPS frame with two ranges, as follows:
+
+~~~
+Largest Acknowledged: 100
+...
+Timestamp Ranges Count: 2
+
+Timestamp Range 1:
+  Delta Largest Acknowledged: 0 // Starting at packet 100
+  Timestamp Delta Count: 5
+  Timestamps Deltas: 380, 10, 10, 5, 5
+
+Timestamp Range 2:
+  Delta Largest Acknowledged: 9 // Starting at packet 91
+  Timestamp Delta Count: 5
+  Timestamp Deltas: 20, 10, 10, 5, 5
+~~~
+
+After that assume that the receiver receives packets 92 to 95 out-of-order at the following timestamps relative to the basis:
+
+| Packet Number    | Relative Timestamp |
+| ---------------- | ------------------ |
+| 92               | 390                |
+| 93               | 392                |
+| 94               | 394                |
+| 95               | 395                |
+
+The receiver MAY send a new ACK_RECEIVE_TIMESTAMPS with all of the timestamps, as follows:
+
+~~~
+Largest Acknowledged: 100
+...
+Timestamp Ranges Count: 3
+
+Timestamp Range 1:
+  Delta Largest Acknowledged: 5 // Starting at packet 95
+  Timestamp Delta Count: 4
+  Timestamps Deltas: 395, 1, 2, 2
+
+Timestamp Range 2:
+  Delta Largest Acknowledged: 0 // Starting at packet 100
+  Timestamp Delta Count: 5
+  Timestamps Deltas: 10, 10, 10, 5, 5
+
+Timestamp Range 2:
+  Delta Largest Acknowledged: 9 // Starting at packet 91
+  Timestamp Delta Count: 5
+  Timestamp Deltas: 20, 10, 10, 5, 5
+~~~
+
+In this particular scenario, the receiver MAY also choose to report the first timestamp range only since the timestamps for the other two ranges have already been reported.
+
 
 
 # Security Considerations


### PR DESCRIPTION
- Revert back to separate frame type for ACK_RECEIVE_TIMESTAMPS
- Add note on using this extension along with the multipath extension
- Add an example to illustrate the frame format and its support for reordering

Addresses https://github.com/wcsmith/draft-quic-receive-ts/issues/7 and  https://github.com/wcsmith/draft-quic-receive-ts/issues/12