### PR TITLE
Update transport param values

### DIFF
--- a/draft-ietf-quic-receive-ts.md
+++ b/draft-ietf-quic-receive-ts.md
@@ -262,7 +262,7 @@ for the most recently received packets and omit timestamps for older packets.
 
 # Extension Negotiation {#negotiation}
 
-max_receive_timestamps_per_ack (0xff0a002 temporary value for draft use):
+max_receive_timestamps_per_ack (0x4ac07 temporary value for draft use):
 
 : A variable-length integer indicating that the maximum number of receive
   timestamps the sending endpoint would like to receive in an
@@ -271,7 +271,7 @@ max_receive_timestamps_per_ack (0xff0a002 temporary value for draft use):
   Each ACK_RECEIVE_TIMESTAMPS or PATH_ACK_RECEIVE_TIMESTAMPS frame sent MUST
   NOT contain more than the peer's maximum number of receive timestamps.
 
-receive_timestamps_exponent (0xff0a003 temporary value for draft use):
+receive_timestamps_exponent (0x4ac26 temporary value for draft use):
 
 : A variable-length integer indicating the exponent to be used when encoding and
   decoding timestamp delta fields in ACK_RECEIVE_TIMESTAMPS and
@@ -407,7 +407,14 @@ TODO Security
 
 # IANA Considerations
 
-This document has no IANA actions.
+This document uses temporary values for the transport parameters
+max_receive_timestamps_per_ack (0x4ac07) and receive_timestamps_exponent
+(0x4ac26), and for the frame types ACK_RECEIVE_TIMESTAMPS
+(0x03178307..0x03178308) and PATH_ACK_RECEIVE_TIMESTAMPS
+(0x03178309..0x0317830a). Prior to publication, these will be replaced with
+permanent registrations in the "QUIC Transport Parameters"
+({{Section 22.3 of !RFC9000}}) and "QUIC Frame Types"
+({{Section 22.4 of !RFC9000}}) registries.
 
 
 --- back


### PR DESCRIPTION
Use new transport param values. This will help with interop testing to differentiate from earlier designs.